### PR TITLE
Fall back to require.resolve if pnpapi is not available

### DIFF
--- a/.changeset/honest-plants-hammer.md
+++ b/.changeset/honest-plants-hammer.md
@@ -1,0 +1,5 @@
+---
+"pnp-sass-importer": major
+---
+
+Fall back to `require.resolve` if `pnpapi` is not available

--- a/packages/pnp-sass-importer/src/importer.ts
+++ b/packages/pnp-sass-importer/src/importer.ts
@@ -17,7 +17,7 @@ export default (dirname: string) => {
                 // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
                 // this import statement will throw. In that scenario, we fallback to require.resolve because
                 // there will be node_modules to traverse
-                pnpapi = await import("pnpapi");
+                pnpapi = (await import("pnpapi")).default;
             } catch (error) {
                 console.log(
                     "pnpapi not found, pnp-sass-importer is not needed outside of a PnP context. Using require.resolve instead",
@@ -41,6 +41,7 @@ export default (dirname: string) => {
                 }
                 return new URL(`file:///${res}`);
             }
+
             let res: string | null = null;
             try {
                 res = pnpapi.resolveRequest(url, dirname);

--- a/packages/pnp-sass-importer/src/importer.ts
+++ b/packages/pnp-sass-importer/src/importer.ts
@@ -15,8 +15,8 @@ export default (dirname: string) => {
             let pnpapi;
             try {
                 // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
-                // this import statement will throw. In that scenario, this importer is actually not necessary
-                // because Sass's --pkg-importer functionality will have node_modules to traverse
+                // this import statement will throw. In that scenario, we fallback to require.resolve because
+                // there will be node_modules to traverse
                 pnpapi = await import("pnpapi");
             } catch (error) {
                 console.log(
@@ -36,7 +36,6 @@ export default (dirname: string) => {
                         });
                     }
                 }
-                // Can't find the module, fallback to the original URL
                 if (res == null) {
                     return null;
                 }

--- a/packages/pnp-sass-importer/src/legacyImporter.ts
+++ b/packages/pnp-sass-importer/src/legacyImporter.ts
@@ -1,5 +1,4 @@
 import { LegacyImporter } from "sass";
-import pnpapi from "pnpapi";
 
 /**
  *
@@ -7,22 +6,35 @@ import pnpapi from "pnpapi";
  * @returns
  */
 export function legacyImporter(dirname: string) {
-    const importer: LegacyImporter = (url, _prev, done) => {
-        let res: string | null = null;
+    const importer: LegacyImporter = async (url, _prev, done) => {
+        let pnpApiPromise;
         try {
-            res = pnpapi.resolveRequest(url, dirname);
+            // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
+            // this import statement will throw. In that scenario, this importer is actually not necessary
+            // because Sass's --pkg-importer functionality will have node_modules to traverse
+            pnpApiPromise = import("pnpapi");
         } catch (error) {
-            // It's possible the package's exports weren't set up correctly and this URL is attempting to reach into the package nonetheless
-            // In that case, we can see if the URL is simply missing a .scss extension and try again
-            if (!url.endsWith(".scss")) {
-                res = pnpapi.resolveRequest(url + ".scss", dirname);
-            }
-        }
-        if (res == null) {
+            console.log("pnpapi not found, pnp-sass-importer is not needed outside of a PnP context. Returning null");
             done(null);
-        } else {
-            done({ file: res.toString() });
+            return;
         }
+        pnpApiPromise.then(pnpapi => {
+            let res: string | null = null;
+            try {
+                res = pnpapi.resolveRequest(url, dirname);
+            } catch (error) {
+                // It's possible the package's exports weren't set up correctly and this URL is attempting to reach into the package nonetheless
+                // In that case, we can see if the URL is simply missing a .scss extension and try again
+                if (!url.endsWith(".scss")) {
+                    res = pnpapi.resolveRequest(url + ".scss", dirname);
+                }
+            }
+            if (res == null) {
+                done(null);
+            } else {
+                done({ file: res.toString() });
+            }
+        });
     };
     return importer;
 }

--- a/packages/pnp-sass-importer/src/legacyImporter.ts
+++ b/packages/pnp-sass-importer/src/legacyImporter.ts
@@ -12,7 +12,7 @@ export function legacyImporter(dirname: string) {
         // this import statement will throw. In that scenario, we fallback to require.resolve because
         // there will be node_modules to traverse
         import("pnpapi")
-            .then(pnpapi => {
+            .then(({ default: pnpapi }) => {
                 let res: string | null = null;
                 try {
                     res = pnpapi.resolveRequest(url, dirname);

--- a/packages/pnp-sass-importer/src/legacyImporter.ts
+++ b/packages/pnp-sass-importer/src/legacyImporter.ts
@@ -1,4 +1,5 @@
 import { LegacyImporter } from "sass";
+import { createRequire } from "node:module";
 
 /**
  *
@@ -7,34 +8,50 @@ import { LegacyImporter } from "sass";
  */
 export function legacyImporter(dirname: string) {
     const importer: LegacyImporter = async (url, _prev, done) => {
-        let pnpApiPromise;
-        try {
-            // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
-            // this import statement will throw. In that scenario, this importer is actually not necessary
-            // because Sass's --pkg-importer functionality will have node_modules to traverse
-            pnpApiPromise = import("pnpapi");
-        } catch (error) {
-            console.log("pnpapi not found, pnp-sass-importer is not needed outside of a PnP context. Returning null");
-            done(null);
-            return;
-        }
-        pnpApiPromise.then(pnpapi => {
-            let res: string | null = null;
-            try {
-                res = pnpapi.resolveRequest(url, dirname);
-            } catch (error) {
-                // It's possible the package's exports weren't set up correctly and this URL is attempting to reach into the package nonetheless
-                // In that case, we can see if the URL is simply missing a .scss extension and try again
-                if (!url.endsWith(".scss")) {
-                    res = pnpapi.resolveRequest(url + ".scss", dirname);
+        // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
+        // this import statement will throw. In that scenario, this importer is actually not necessary
+        // because Sass's --pkg-importer functionality will have node_modules to traverse
+        import("pnpapi")
+            .then(pnpapi => {
+                let res: string | null = null;
+                try {
+                    res = pnpapi.resolveRequest(url, dirname);
+                } catch (error) {
+                    // It's possible the package's exports weren't set up correctly and this URL is attempting to reach into the package nonetheless
+                    // In that case, we can see if the URL is simply missing a .scss extension and try again
+                    if (!url.endsWith(".scss")) {
+                        res = pnpapi.resolveRequest(url + ".scss", dirname);
+                    }
                 }
-            }
-            if (res == null) {
-                done(null);
-            } else {
-                done({ file: res.toString() });
-            }
-        });
+                if (res == null) {
+                    done(null);
+                } else {
+                    done({ file: res.toString() });
+                }
+            })
+            .catch(() => {
+                console.log(
+                    "pnpapi not found, pnp-sass-importer is not needed outside of a PnP context. Using require.resolve instead",
+                );
+                const require = createRequire(dirname);
+                try {
+                    done({
+                        file: require.resolve(url, {
+                            paths: [dirname],
+                        }),
+                    });
+                } catch (error) {
+                    // It's possible the package's exports weren't set up correctly and this URL is attempting to reach into the package nonetheless
+                    // In that case, we can see if the URL is simply missing a .scss extension and try again
+                    if (!url.endsWith(".scss")) {
+                        done({
+                            file: require.resolve(url + ".scss", {
+                                paths: [dirname],
+                            }),
+                        });
+                    }
+                }
+            });
     };
     return importer;
 }

--- a/packages/pnp-sass-importer/src/legacyImporter.ts
+++ b/packages/pnp-sass-importer/src/legacyImporter.ts
@@ -9,8 +9,8 @@ import { createRequire } from "node:module";
 export function legacyImporter(dirname: string) {
     const importer: LegacyImporter = async (url, _prev, done) => {
         // If this plugin is not actually run in a PnP context (e.g. nodeLinker is set to node-modules),
-        // this import statement will throw. In that scenario, this importer is actually not necessary
-        // because Sass's --pkg-importer functionality will have node_modules to traverse
+        // this import statement will throw. In that scenario, we fallback to require.resolve because
+        // there will be node_modules to traverse
         import("pnpapi")
             .then(pnpapi => {
                 let res: string | null = null;


### PR DESCRIPTION
I was trying to use this in a project deployed to Vercel, but sadly Vercel does not fully support PnP at this time and actually force-sets `nodeLinker: node-modules` when running a `yarn install`. This means that this importer will throw at runtime because `pnpapi` cannot be found.

To be more resilient, this importer will fallback to `require.resolve`, which should work if `pnpapi` is not found because that presumes there are `node_modules` to traverse.